### PR TITLE
add instance HasOpenAPI ({Summary,Description} s :> api)

### DIFF
--- a/servant-openapi/src/Servant/OpenAPI/Internal.hs
+++ b/servant-openapi/src/Servant/OpenAPI/Internal.hs
@@ -220,6 +220,22 @@ addParam param = over #parameters $
 
 instance
   ( HasOpenAPI api
+  , KnownSymbol s
+  ) => HasOpenAPI (Description s :> api) where
+    toEndpointInfo Proxy = set #description (Just description) <$> toEndpointInfo @api Proxy
+      where
+        description = Text.pack . symbolVal $ Proxy @s
+
+instance
+  ( HasOpenAPI api
+  , KnownSymbol s
+  ) => HasOpenAPI (Summary s :> api) where
+    toEndpointInfo Proxy = set #summary (Just summary) <$> toEndpointInfo @api Proxy
+      where
+        summary = Text.pack . symbolVal $ Proxy @s
+
+instance
+  ( HasOpenAPI api
   , ToOpenAPISchema a
   , SBoolI (FoldLenient mods))
   => HasOpenAPI


### PR DESCRIPTION
Hey, this PR simply adds `HasOpenAPI` instances for the [`Servant.API.Description`](https://hackage.haskell.org/package/servant-0.18.2/docs/Servant-API-Description.html) types `Description` and `Summary`, to allow users to add these as part of their API types. I believe these should do the right thing, propagating the `description`/`summary` to the nodes under `:>`.