### PR TITLE
apply description and summary to all operation objects

### DIFF
--- a/servant-openapi/src/Servant/OpenAPI/Internal.hs
+++ b/servant-openapi/src/Servant/OpenAPI/Internal.hs
@@ -222,7 +222,8 @@ instance
   ( HasOpenAPI api
   , KnownSymbol s
   ) => HasOpenAPI (Description s :> api) where
-    toEndpointInfo Proxy = set #description (Just description) <$> toEndpointInfo @api Proxy
+    toEndpointInfo Proxy =
+      mapOperations (set #description (Just description)) <$> toEndpointInfo @api Proxy
       where
         description = Text.pack . symbolVal $ Proxy @s
 
@@ -230,7 +231,8 @@ instance
   ( HasOpenAPI api
   , KnownSymbol s
   ) => HasOpenAPI (Summary s :> api) where
-    toEndpointInfo Proxy = set #summary (Just summary) <$> toEndpointInfo @api Proxy
+    toEndpointInfo Proxy =
+      mapOperations (set #summary (Just summary)) <$> toEndpointInfo @api Proxy
       where
         summary = Text.pack . symbolVal $ Proxy @s
 


### PR DESCRIPTION
When I tried to render a schema with `Description` and `Summary` using [redoc](https://github.com/Redocly/redoc/blob/master/cli/README.md), I noticed that the values were not showing up. I looked at the produced yaml and noticed that the values were there, but beside rather than under the method, that is,

```yaml
paths:
  /my/path:
    get: 
      responses: { ... }
      parameters: [ ... ]
    summary: my summary
    description: my description
```

I found that nesting `summary` and `description` under the method allowed redoc to render the right information, like this,

```yaml
paths:
  /my/path:
    get: 
      responses: { ... }
      parameters: [ ... ]
      summary: my summary
      description: my description
```

Seeing that this worked, I applied the corresponding change in the instances, it was just a matter of using `mapOperations` to set the `description` and `summary` fields under the method rather than next to it.